### PR TITLE
fix: use getAllByText instead of getByText in Stats test - Fixes #11

### DIFF
--- a/tests/unit/components/Stats.test.tsx
+++ b/tests/unit/components/Stats.test.tsx
@@ -6,11 +6,11 @@ describe('Stats Section', () => {
   it('renders all stat cards', () => {
     render(<Stats />);
     
-    // Check for stat headings
-    expect(screen.getByText(/BPM Detection Accuracy/i)).toBeInTheDocument();
-    expect(screen.getByText(/Average Analysis Time/i)).toBeInTheDocument();
-    expect(screen.getByText(/Supported Platforms/i)).toBeInTheDocument();
-    expect(screen.getByText(/Monthly Plan/i)).toBeInTheDocument();
+    // Check for stat headings (using getAllByText since component renders for mobile + desktop)
+    expect(screen.getAllByText(/BPM Detection Accuracy/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Average Analysis Time/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Supported Platforms/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/Monthly Plan/i)[0]).toBeInTheDocument();
   });
 
   it('displays correct stat values', () => {
@@ -20,9 +20,9 @@ describe('Stats Section', () => {
     const heading = screen.getByRole('heading', { name: /Powered by Numbers/i });
     expect(heading).toBeInTheDocument();
     
-    // Check for comparison badges
-    expect(screen.getByText(/15% better than competitors/i)).toBeInTheDocument();
-    expect(screen.getByText(/3x faster than average/i)).toBeInTheDocument();
+    // Check for comparison badges (using getAllByText since component renders for mobile + desktop)
+    expect(screen.getAllByText(/15% better than competitors/i)[0]).toBeInTheDocument();
+    expect(screen.getAllByText(/3x faster than average/i)[0]).toBeInTheDocument();
   });
 
   it('has proper semantic structure', () => {


### PR DESCRIPTION
## Fixes
Closes #11

## Changes
- Fixed 'renders all stat cards' test by using getAllByText for stat headings
- Fixed 'displays correct stat values' test by using getAllByText for comparison badges
- Stats component renders duplicate elements (mobile + desktop viewports)
- Using getAllByText()[0] correctly targets the first occurrence

## Test Results
✅ All 24 unit tests passing

## Scope
- 1 file changed
- 8 insertions/deletions
- Simple test assertion fix

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only assertion change that broadens selectors to handle duplicate DOM nodes; no runtime or data/security impact.
> 
> **Overview**
> Updates `Stats.test.tsx` to use `getAllByText(...)[0]` instead of `getByText` for stat headings and comparison badges, avoiding failures when the `Stats` section renders duplicate text for mobile + desktop layouts.
> 
> No production code changes; this is a targeted unit test robustness fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dedd93088061c1e70360b40bbc87be0ebcba1521. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->